### PR TITLE
fix: flatten_json appends parent object keys to children in both objects and arrays instead of just arrays

### DIFF
--- a/flatten-json/main.go
+++ b/flatten-json/main.go
@@ -16,12 +16,19 @@ func FlattenMessages(message []byte, headers map[string]string, inputs map[strin
 				out_map[parent_key] = value
 			case map[string]interface{}:
 				for key, value := range value_typed {
-					recursiveFlatten(out_map, value, key)
+					var new_key string
+					if len(parent_key) > 0{
+						new_key = fmt.Sprintf("%s_%s", parent_key, key)
+					}else{
+						new_key = key
+					}
+
+					recursiveFlatten(out_map, value, new_key)
 				}
 			case []interface{}:
 				for index, value := range value_typed {
-					new_name := fmt.Sprintf("%s_%d", parent_key, index)
-					recursiveFlatten(out_map, value, new_name)
+					new_key := fmt.Sprintf("%s_%d", parent_key, index)
+					recursiveFlatten(out_map, value, new_key)
 				}
 			}
 		}


### PR DESCRIPTION
EX: 

Input:
```json
{
    "outer_object": {
        "inner_object": {
            "inner_key": "value"
        }
    },
    "outer_array":[
        1,
        2,
        "three"
    ],
    "not_nested": "is unchanged"
}
```

Output:

```json
{
    "not_nested": "is unchanged",
    "outer_array_0": 1,
    "outer_array_1": 2,
    "outer_array_2": "three",
    "outer_object_inner_object_inner_key": "value"
}
```